### PR TITLE
Add sales ETL pipeline project scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# Sales ETL Pipeline
+
+This project provides a modular, production-ready Sales ETL pipeline that extracts data from a CSV file or public API, transforms it for analytics, and loads it into PostgreSQL. The pipeline can be orchestrated with Apache Airflow.
+
+## Project Structure
+
+```
+.
+├── config/
+│   └── config.py
+├── data/
+│   └── raw_sales.csv
+├── orchestration/
+│   └── sales_etl_dag.py
+├── scripts/
+│   ├── extract_sales.py
+│   ├── transform_sales.py
+│   └── load_sales.py
+├── sql/
+│   └── schema.sql
+├── requirements.txt
+└── README.md
+```
+
+## Features
+
+- **Extract** sales data from CSV or API sources.
+- **Transform** data by cleaning, handling missing values, and computing total sales.
+- **Load** analytics-ready data into PostgreSQL.
+- **Orchestrate** daily runs with an Airflow DAG.
+- **Logging & error handling** built into each script.
+
+## Setup
+
+### 1) Install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 2) Create database tables
+
+```bash
+psql "postgresql://etl_user:etl_password@localhost:5432/sales_dw" -f sql/schema.sql
+```
+
+### 3) Configure environment variables
+
+Set the following environment variables (sample values shown):
+
+```bash
+export DATABASE_URL="postgresql+psycopg2://etl_user:etl_password@localhost:5432/sales_dw"
+export RAW_SALES_PATH="data/raw_sales.csv"
+export SOURCE_SYSTEM="csv"  # or "api"
+export SALES_API_URL="https://api.sampleapis.com/coffee/hot"
+```
+
+### 4) Run the pipeline locally
+
+```bash
+python scripts/extract_sales.py
+python scripts/transform_sales.py
+python scripts/load_sales.py
+```
+
+## Orchestration (Airflow)
+
+1. Copy `orchestration/sales_etl_dag.py` into your Airflow DAGs folder.
+2. Ensure Airflow uses the same Python environment with dependencies installed.
+3. Configure the environment variables in your Airflow connections or environment.
+4. The DAG runs **daily** with `@daily` schedule.
+
+## How the ETL Works
+
+### Extract
+- Reads CSV data or calls the API depending on `SOURCE_SYSTEM`.
+- Logs record counts and errors during extraction.
+
+### Transform
+- Standardizes column names.
+- Handles missing values for quantity, price, and currency.
+- Converts timestamps to dates and calculates total sale values.
+
+### Load
+- Inserts transformed data into the `analytics_sales` table using SQLAlchemy.
+
+## Database Schema
+
+The schema includes:
+- `raw_sales`: raw data from ingestion.
+- `analytics_sales`: cleansed and enriched data for analytics.
+
+See [`sql/schema.sql`](sql/schema.sql) for full definitions.
+
+## Production Considerations
+
+- Replace the sample API with your production data source.
+- Add schema validations and duplicate detection before loading.
+- Configure Airflow retries, alerting, and SLA monitoring.
+- Use a secrets manager for `DATABASE_URL`.
+
+## Example Database Connection
+
+```python
+from sqlalchemy import create_engine
+
+engine = create_engine("postgresql+psycopg2://etl_user:etl_password@localhost:5432/sales_dw")
+with engine.begin() as connection:
+    connection.execute("SELECT 1")
+```

--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,31 @@
+"""Centralized configuration loading for the ETL pipeline."""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    """Runtime configuration loaded from environment variables."""
+
+    database_url: str
+    raw_sales_path: str
+    source_system: str
+    api_url: str
+
+
+def load_settings() -> Settings:
+    """Load settings from environment variables with sensible defaults."""
+
+    return Settings(
+        database_url=os.getenv(
+            "DATABASE_URL",
+            "postgresql+psycopg2://etl_user:etl_password@localhost:5432/sales_dw",
+        ),
+        raw_sales_path=os.getenv("RAW_SALES_PATH", "data/raw_sales.csv"),
+        source_system=os.getenv("SOURCE_SYSTEM", "csv"),
+        api_url=os.getenv(
+            "SALES_API_URL",
+            "https://api.sampleapis.com/coffee/hot",
+        ),
+    )

--- a/data/raw_sales.csv
+++ b/data/raw_sales.csv
@@ -1,0 +1,4 @@
+sale_id,sale_timestamp,customer_id,product_id,quantity,unit_price,currency,source_system
+S-1001,2024-01-15T10:15:00Z,C-001,P-100,2,19.99,USD,csv
+S-1002,2024-01-15T11:20:00Z,C-002,P-200,1,99.99,USD,csv
+S-1003,2024-01-16T09:05:00Z,C-003,P-300,3,5.50,USD,csv

--- a/orchestration/sales_etl_dag.py
+++ b/orchestration/sales_etl_dag.py
@@ -1,0 +1,40 @@
+"""Airflow DAG to orchestrate the sales ETL pipeline."""
+
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+
+DEFAULT_ARGS = {
+    "owner": "data-engineering",
+    "depends_on_past": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="sales_etl_pipeline",
+    default_args=DEFAULT_ARGS,
+    description="Daily sales ETL pipeline",
+    schedule_interval="@daily",
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["sales", "etl"],
+) as dag:
+    extract_task = BashOperator(
+        task_id="extract_sales",
+        bash_command="python scripts/extract_sales.py",
+    )
+
+    transform_task = BashOperator(
+        task_id="transform_sales",
+        bash_command="python scripts/transform_sales.py",
+    )
+
+    load_task = BashOperator(
+        task_id="load_sales",
+        bash_command="python scripts/load_sales.py",
+    )
+
+    extract_task >> transform_task >> load_task

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+apache-airflow==2.8.1
+pandas==2.2.0
+psycopg2-binary==2.9.9
+requests==2.31.0
+SQLAlchemy==2.0.25

--- a/scripts/extract_sales.py
+++ b/scripts/extract_sales.py
@@ -1,0 +1,84 @@
+"""Extract raw sales data from a CSV file or public API."""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Any
+
+import pandas as pd
+import requests
+
+from config.config import load_settings
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+logger = logging.getLogger("extract_sales")
+
+
+def _read_csv(path: str) -> pd.DataFrame:
+    """Read sales data from a local CSV file."""
+
+    logger.info("Reading CSV from %s", path)
+    return pd.read_csv(path)
+
+
+def _read_api(url: str) -> pd.DataFrame:
+    """Read sales-like data from a public API endpoint."""
+
+    logger.info("Fetching data from API %s", url)
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    payload: List[Dict[str, Any]] = response.json()
+    logger.info("Received %d records from API", len(payload))
+
+    normalized = []
+    for record in payload:
+        normalized.append(
+            {
+                "sale_id": record.get("id") or record.get("title"),
+                "sale_timestamp": datetime.utcnow().isoformat(),
+                "customer_id": record.get("title", "unknown").replace(" ", "_").lower(),
+                "product_id": record.get("title", "product").replace(" ", "_").lower(),
+                "quantity": 1,
+                "unit_price": 5.00,
+                "currency": "USD",
+                "source_system": "api",
+            }
+        )
+
+    return pd.DataFrame(normalized)
+
+
+def extract_sales() -> pd.DataFrame:
+    """Extract sales data based on the configured source."""
+
+    settings = load_settings()
+    try:
+        if settings.source_system.lower() == "api":
+            data_frame = _read_api(settings.api_url)
+        else:
+            data_frame = _read_csv(settings.raw_sales_path)
+    except (OSError, requests.RequestException, json.JSONDecodeError) as exc:
+        logger.error("Failed to extract sales data: %s", exc)
+        raise
+
+    logger.info("Extracted %d records", len(data_frame))
+    return data_frame
+
+
+def main() -> None:
+    """CLI entrypoint for running extraction."""
+
+    data_frame = extract_sales()
+    output_path = Path("data/raw_sales_extracted.csv")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    data_frame.to_csv(output_path, index=False)
+    logger.info("Wrote extracted data to %s", output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/load_sales.py
+++ b/scripts/load_sales.py
@@ -1,0 +1,55 @@
+"""Load transformed sales data into the analytics database."""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+
+from config.config import load_settings
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+logger = logging.getLogger("load_sales")
+
+
+def load_sales(analytics_sales: pd.DataFrame, database_url: str) -> None:
+    """Insert analytics sales data into PostgreSQL tables."""
+
+    engine = create_engine(database_url)
+    try:
+        with engine.begin() as connection:
+            logger.info("Loading %d records into analytics_sales", len(analytics_sales))
+            analytics_sales.to_sql(
+                "analytics_sales",
+                con=connection,
+                if_exists="append",
+                index=False,
+                method="multi",
+            )
+            logger.info("Data load complete")
+    except SQLAlchemyError as exc:
+        logger.error("Failed to load data: %s", exc)
+        raise
+
+
+def main() -> None:
+    """CLI entrypoint for loading data."""
+
+    settings = load_settings()
+    input_path = Path("data/analytics_sales.csv")
+    if not input_path.exists():
+        raise FileNotFoundError(
+            "Transformed data not found. Run transform_sales.py first."
+        )
+
+    analytics_sales = pd.read_csv(input_path)
+    load_sales(analytics_sales, settings.database_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/transform_sales.py
+++ b/scripts/transform_sales.py
@@ -1,0 +1,87 @@
+"""Transform raw sales data into analytics-ready format."""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from config.config import load_settings
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+logger = logging.getLogger("transform_sales")
+
+
+def transform_sales(raw_sales: pd.DataFrame) -> pd.DataFrame:
+    """Clean, normalize, and enrich raw sales data."""
+
+    logger.info("Starting transformation on %d records", len(raw_sales))
+
+    cleaned = raw_sales.copy()
+    cleaned.columns = [column.strip().lower() for column in cleaned.columns]
+
+    required_columns = {
+        "sale_id",
+        "sale_timestamp",
+        "customer_id",
+        "product_id",
+        "quantity",
+        "unit_price",
+        "currency",
+        "source_system",
+    }
+
+    missing_columns = required_columns - set(cleaned.columns)
+    if missing_columns:
+        message = f"Missing required columns: {sorted(missing_columns)}"
+        logger.error(message)
+        raise ValueError(message)
+
+    cleaned["quantity"] = cleaned["quantity"].fillna(0).astype(int)
+    cleaned["unit_price"] = cleaned["unit_price"].fillna(0).astype(float)
+    cleaned["currency"] = cleaned["currency"].fillna("USD")
+    cleaned["sale_timestamp"] = pd.to_datetime(
+        cleaned["sale_timestamp"], errors="coerce"
+    )
+
+    cleaned = cleaned.dropna(subset=["sale_id", "sale_timestamp"])
+    cleaned["total_sale"] = cleaned["quantity"] * cleaned["unit_price"]
+    cleaned["sale_date"] = cleaned["sale_timestamp"].dt.date
+
+    analytics = cleaned[
+        [
+            "sale_id",
+            "sale_date",
+            "customer_id",
+            "product_id",
+            "quantity",
+            "unit_price",
+            "total_sale",
+            "currency",
+            "source_system",
+        ]
+    ]
+
+    logger.info("Transformation complete with %d records", len(analytics))
+    return analytics
+
+
+def main() -> None:
+    """CLI entrypoint for running transformations."""
+
+    settings = load_settings()
+    input_path = Path(settings.raw_sales_path)
+    raw_sales = pd.read_csv(input_path)
+    analytics = transform_sales(raw_sales)
+
+    output_path = Path("data/analytics_sales.csv")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    analytics.to_csv(output_path, index=False)
+    logger.info("Wrote transformed data to %s", output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,32 @@
+-- Schema for raw and analytics sales data (PostgreSQL)
+
+CREATE TABLE IF NOT EXISTS raw_sales (
+    sale_id TEXT PRIMARY KEY,
+    sale_timestamp TIMESTAMP NOT NULL,
+    customer_id TEXT NOT NULL,
+    product_id TEXT NOT NULL,
+    quantity INTEGER NOT NULL,
+    unit_price NUMERIC(12, 2) NOT NULL,
+    currency TEXT NOT NULL,
+    source_system TEXT NOT NULL,
+    ingestion_timestamp TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS analytics_sales (
+    sale_id TEXT PRIMARY KEY,
+    sale_date DATE NOT NULL,
+    customer_id TEXT NOT NULL,
+    product_id TEXT NOT NULL,
+    quantity INTEGER NOT NULL,
+    unit_price NUMERIC(12, 2) NOT NULL,
+    total_sale NUMERIC(14, 2) NOT NULL,
+    currency TEXT NOT NULL,
+    source_system TEXT NOT NULL,
+    transformed_timestamp TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_sales_date
+    ON raw_sales (sale_timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_sales_date
+    ON analytics_sales (sale_date);


### PR DESCRIPTION
### Motivation

- Provide a complete end-to-end Sales ETL pipeline that extracts from CSV or API, transforms and enriches records, and loads analytics-ready data into PostgreSQL on a daily schedule.
- Establish a modular, configurable project layout with separate folders for SQL, Python scripts, orchestration, configuration, and sample data to make the pipeline production-ready and easy to extend.

### Description

- Add PostgreSQL schema `sql/schema.sql` defining `raw_sales` and `analytics_sales` tables with indexes for date columns.
- Add centralized configuration `config/config.py`, sample CSV `data/raw_sales.csv`, and `requirements.txt` listing runtime dependencies.
- Implement extraction, transformation, and load scripts `scripts/extract_sales.py`, `scripts/transform_sales.py`, and `scripts/load_sales.py` with logging, error handling, `main()` entrypoints, CSV/API extraction, cleaning (missing values), `total_sale` computation, and SQLAlchemy-based loading (import cleanup applied to the loader).
- Add an Airflow DAG `orchestration/sales_etl_dag.py` to orchestrate daily runs and a `README.md` with setup, env vars, run instructions, and an example DB connection.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989789e20d08329a1414beac9b46d0b)